### PR TITLE
Added MFA support

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": {
         "en": "Ring"
     },
-    "version": "2.1.4",
+    "version": "2.2.0",
     "compatibility": ">=3.2.0",
     "sdk": 2,
     "author": {
@@ -16,6 +16,10 @@
             "name": "Dennie de Groot",
             "email": "mail@denniedegroot.nl",
             "website": "https://denniedegroot.nl"
+        },
+        {
+            "name": "Kaoh",
+            "email": "kaoh@kaoh.nl"
         }]
     },
     "contributing": {

--- a/drivers/chime/pair/start.html
+++ b/drivers/chime/pair/start.html
@@ -1,15 +1,83 @@
-<script type="text/javascript">
-	$('#authentication_text' ).hide();
 
-	Homey.emit('authenticate', {}, function(err, result) {
-		console.log(err, result);
-		if (err || !result) {
-			Homey.setTitle(__( 'pair.authorization' ));
-			$('#authentication_text').show();
-		} else {
-			Homey.showView('list_devices');
-		}
-	});
-</script>
+    <h1 data-i18n="settings.title"></h1>
+    <p data-i18n="settings.intro"></p>
+    <p style='color: orange;' data-i18n="settings.auth.warning"></legend>
 
-<p id="authentication_text" data-i18n="pair.authorization_explanation"></p>
+    <fieldset>
+        <legend data-i18n="settings.auth.header"></legend>
+
+        <div id="settings-auth">
+            <p id="error" style='color: red;'></p>
+
+            <div class="field row" id="auth-row-user">
+                <label class="form-label" for="settings-auth-user" data-i18n="settings.auth.user"></label>
+                <input class="form-input" id="settings-auth-user" data-i18n-placeholder="" type="text" value=""/>
+            </div>
+
+            <div class="field row" id="auth-row-pass">
+                <label class="form-label" for="settings-auth-pass" data-i18n="settings.auth.pass"></label>
+                <input class="form-input" id="settings-auth-pass" data-i18n-placeholder="" type="password" value=""/>
+            </div>
+
+            <div class="field row" id="auth-row-code" style="display: none;">
+                <label class="form-label" for="settings-auth-token" data-i18n="settings.auth.token"></label>
+                <input class="form-input" id="settings-auth-token" data-i18n-placeholder="" type="text" value=""/>
+            </div>
+
+            <button id="settings-auth-authenticate" data-i18n="settings.auth.authenticate"></button>
+            <button id="settings-auth-validatecode" data-i18n="settings.auth.validatecode" style="display: none;"></button>
+        </div>
+
+    </fieldset>
+
+    <script type="text/javascript">
+
+        document.getElementById('settings-auth-authenticate').addEventListener('click', function(elem) {
+            onAuth(Homey);
+        });
+
+        document.getElementById('settings-auth-validatecode').addEventListener('click', function(elem) {
+            onCode(Homey);
+        });
+
+
+        function onAuth(Homey) {
+            var auth = {};
+            auth.user = document.getElementById('settings-auth-user').value;
+            auth.pass = document.getElementById('settings-auth-pass').value;
+
+            Homey.emit( 'triggerMFA', auth, function(err, result)
+            {
+                alert(result);
+                if(err)
+                    document.getElementById('error').innerHTML = 'Error: ' + err;
+                else
+                    showToken();
+            });
+        }
+
+        function onCode(Homey) {
+            var auth = {};
+            auth.user = document.getElementById('settings-auth-user').value;
+            auth.pass = document.getElementById('settings-auth-pass').value;
+            auth.token = document.getElementById('settings-auth-token').value;
+
+            Homey.emit( 'validateMFA', auth, function(err, result)
+            {
+                if(err)
+                    document.getElementById('error').innerHTML = 'Error: ' + err;
+                else
+                    Homey.nextView();
+            });
+        }
+
+        function showToken() {
+            document.getElementById('auth-row-user').style.display = 'none';
+            document.getElementById('auth-row-pass').style.display = 'none';
+            document.getElementById('settings-auth-authenticate').style.display = 'none';
+            document.getElementById('auth-row-code').style.display = 'block';
+            document.getElementById('settings-auth-validatecode').style.display = 'block';
+        }
+
+    </script>
+

--- a/drivers/doorbell/pair/start.html
+++ b/drivers/doorbell/pair/start.html
@@ -1,14 +1,83 @@
-<script type="text/javascript">
-	$('#authentication_text' ).hide();
 
-	Homey.emit('authenticate', {}, function(err, result) {
-		if (err || !result) {
-			Homey.setTitle(__( 'pair.authorization' ));
-			$('#authentication_text').show();
-		} else {
-			Homey.showView('list_devices');
-		}
-	});
-</script>
+    <h1 data-i18n="settings.title"></h1>
+    <p data-i18n="settings.intro"></p>
+    <p style='color: orange;' data-i18n="settings.auth.warning"></legend>
 
-<p id="authentication_text" data-i18n="pair.authorization_explanation"></p>
+    <fieldset>
+        <legend data-i18n="settings.auth.header"></legend>
+
+        <div id="settings-auth">
+            <p id="error" style='color: red;'></p>
+
+            <div class="field row" id="auth-row-user">
+                <label class="form-label" for="settings-auth-user" data-i18n="settings.auth.user"></label>
+                <input class="form-input" id="settings-auth-user" data-i18n-placeholder="" type="text" value=""/>
+            </div>
+
+            <div class="field row" id="auth-row-pass">
+                <label class="form-label" for="settings-auth-pass" data-i18n="settings.auth.pass"></label>
+                <input class="form-input" id="settings-auth-pass" data-i18n-placeholder="" type="password" value=""/>
+            </div>
+
+            <div class="field row" id="auth-row-code" style="display: none;">
+                <label class="form-label" for="settings-auth-token" data-i18n="settings.auth.token"></label>
+                <input class="form-input" id="settings-auth-token" data-i18n-placeholder="" type="text" value=""/>
+            </div>
+
+            <button id="settings-auth-authenticate" data-i18n="settings.auth.authenticate"></button>
+            <button id="settings-auth-validatecode" data-i18n="settings.auth.validatecode" style="display: none;"></button>
+        </div>
+
+    </fieldset>
+
+    <script type="text/javascript">
+
+        document.getElementById('settings-auth-authenticate').addEventListener('click', function(elem) {
+            onAuth(Homey);
+        });
+
+        document.getElementById('settings-auth-validatecode').addEventListener('click', function(elem) {
+            onCode(Homey);
+        });
+
+
+        function onAuth(Homey) {
+            var auth = {};
+            auth.user = document.getElementById('settings-auth-user').value;
+            auth.pass = document.getElementById('settings-auth-pass').value;
+
+            Homey.emit( 'triggerMFA', auth, function(err, result)
+            {
+                alert(result);
+                if(err)
+                    document.getElementById('error').innerHTML = 'Error: ' + err;
+                else
+                    showToken();
+            });
+        }
+
+        function onCode(Homey) {
+            var auth = {};
+            auth.user = document.getElementById('settings-auth-user').value;
+            auth.pass = document.getElementById('settings-auth-pass').value;
+            auth.token = document.getElementById('settings-auth-token').value;
+
+            Homey.emit( 'validateMFA', auth, function(err, result)
+            {
+                if(err)
+                    document.getElementById('error').innerHTML = 'Error: ' + err;
+                else
+                    Homey.nextView();
+            });
+        }
+
+        function showToken() {
+            document.getElementById('auth-row-user').style.display = 'none';
+            document.getElementById('auth-row-pass').style.display = 'none';
+            document.getElementById('settings-auth-authenticate').style.display = 'none';
+            document.getElementById('auth-row-code').style.display = 'block';
+            document.getElementById('settings-auth-validatecode').style.display = 'block';
+        }
+
+    </script>
+

--- a/drivers/stickupcam/pair/start.html
+++ b/drivers/stickupcam/pair/start.html
@@ -1,15 +1,83 @@
-<script type="text/javascript">
-	$('#authentication_text' ).hide();
 
-	Homey.emit('authenticate', {}, function(err, result) {
-		console.log(err, result);
-		if (err || !result) {
-			Homey.setTitle(__( 'pair.authorization' ));
-			$('#authentication_text').show();
-		} else {
-			Homey.showView('list_devices');
-		}
-	});
-</script>
+    <h1 data-i18n="settings.title"></h1>
+    <p data-i18n="settings.intro"></p>
+    <p style='color: orange;' data-i18n="settings.auth.warning"></legend>
 
-<p id="authentication_text" data-i18n="pair.authorization_explanation"></p>
+    <fieldset>
+        <legend data-i18n="settings.auth.header"></legend>
+
+        <div id="settings-auth">
+            <p id="error" style='color: red;'></p>
+
+            <div class="field row" id="auth-row-user">
+                <label class="form-label" for="settings-auth-user" data-i18n="settings.auth.user"></label>
+                <input class="form-input" id="settings-auth-user" data-i18n-placeholder="" type="text" value=""/>
+            </div>
+
+            <div class="field row" id="auth-row-pass">
+                <label class="form-label" for="settings-auth-pass" data-i18n="settings.auth.pass"></label>
+                <input class="form-input" id="settings-auth-pass" data-i18n-placeholder="" type="password" value=""/>
+            </div>
+
+            <div class="field row" id="auth-row-code" style="display: none;">
+                <label class="form-label" for="settings-auth-token" data-i18n="settings.auth.token"></label>
+                <input class="form-input" id="settings-auth-token" data-i18n-placeholder="" type="text" value=""/>
+            </div>
+
+            <button id="settings-auth-authenticate" data-i18n="settings.auth.authenticate"></button>
+            <button id="settings-auth-validatecode" data-i18n="settings.auth.validatecode" style="display: none;"></button>
+        </div>
+
+    </fieldset>
+
+    <script type="text/javascript">
+
+        document.getElementById('settings-auth-authenticate').addEventListener('click', function(elem) {
+            onAuth(Homey);
+        });
+
+        document.getElementById('settings-auth-validatecode').addEventListener('click', function(elem) {
+            onCode(Homey);
+        });
+
+
+        function onAuth(Homey) {
+            var auth = {};
+            auth.user = document.getElementById('settings-auth-user').value;
+            auth.pass = document.getElementById('settings-auth-pass').value;
+
+            Homey.emit( 'triggerMFA', auth, function(err, result)
+            {
+                alert(result);
+                if(err)
+                    document.getElementById('error').innerHTML = 'Error: ' + err;
+                else
+                    showToken();
+            });
+        }
+
+        function onCode(Homey) {
+            var auth = {};
+            auth.user = document.getElementById('settings-auth-user').value;
+            auth.pass = document.getElementById('settings-auth-pass').value;
+            auth.token = document.getElementById('settings-auth-token').value;
+
+            Homey.emit( 'validateMFA', auth, function(err, result)
+            {
+                if(err)
+                    document.getElementById('error').innerHTML = 'Error: ' + err;
+                else
+                    Homey.nextView();
+            });
+        }
+
+        function showToken() {
+            document.getElementById('auth-row-user').style.display = 'none';
+            document.getElementById('auth-row-pass').style.display = 'none';
+            document.getElementById('settings-auth-authenticate').style.display = 'none';
+            document.getElementById('auth-row-code').style.display = 'block';
+            document.getElementById('settings-auth-validatecode').style.display = 'block';
+        }
+
+    </script>
+

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -35,7 +35,7 @@ class Api extends Homey.SimpleClass {
 
         setInterval(this._refreshDevice.bind(this), refreshDeviceInterval);
         setInterval(this._refreshDevices.bind(this), refreshDevicesInterval);
-        setInterval(this._verifyAuthentication.bind(this), verifyAuthenticationInterval);
+        //setInterval(this._verifyAuthentication.bind(this), verifyAuthenticationInterval);
     }
 
     init () {
@@ -133,15 +133,19 @@ class Api extends Homey.SimpleClass {
         request.end();
     }
 
-    _https_auth (callback) {
-        console.log('_https_auth');
-
-        let auth = Homey.ManagerSettings.get('ringCredentials');
-
-        if (auth === null || auth === undefined) {
-            return callback(new Error('invalid_credentials'));
-        }
-
+    _https_auth_postdata_refresh () {
+        let refreshToken = Homey.ManagerSettings.get('ringRefreshToken');
+        //console.log('current refresh token ['+refreshToken+']');
+        let postdata = JSON.stringify({
+            client_id: "ring_official_android",
+            grant_type: "refresh_token",
+            refresh_token: refreshToken,
+            scope: "client"
+        });
+        return postdata;           
+    }
+    _https_auth_postdata_auth (auth)
+    {
         let postdata = JSON.stringify({
             client_id: "ring_official_android",
             grant_type: "password",
@@ -149,6 +153,13 @@ class Api extends Homey.SimpleClass {
             password: auth.pass,
             scope: "client"
         });
+        return postdata;
+    }
+
+    _https_auth_mfa_refresh (callback) {
+        console.log('_https_auth_mfa_refresh');
+
+        let postdata = this._https_auth_postdata_refresh();
 
         var timeout = setTimeout(() => {
             request.abort();
@@ -159,6 +170,7 @@ class Api extends Homey.SimpleClass {
         url.headers = {
             'hardware_id': this._uniqueid,
             'content-type': 'application/json',
+            '2fa-support': 'true',
             'content-length': postdata.length
         };
 
@@ -175,11 +187,161 @@ class Api extends Homey.SimpleClass {
 
                 if (response.statusCode >= 400) {
                     this._authenticated = false;
-                    console.log('_https_auth : invalid_authentication : ', response.statusCode);
+                    console.log('_https_auth_mfa_refresh : invalid_refresh : ', response.statusCode);
+                    error = new Error('invalid_refresh ' + response.statusCode + ' ' + data);
+                } else {
+                    try {
+                        result = JSON.parse(data);
+                    } catch (e) {
+                        error = e;
+                    }
+                }
+
+                clearTimeout(timeout);
+                console.log('_https_auth_mfa_refresh: update cached refresh token for later use')
+                Homey.ManagerSettings.set('ringRefreshToken', result.refresh_token);
+                callback(error, result);
+            });
+
+            response.on('error', (error) => {
+                clearTimeout(timeout);
+                callback(error);
+            });
+        });
+
+        request.on('error', (error) => {
+            clearTimeout(timeout);
+            callback(error);
+        });
+
+        request.write(postdata);
+
+        request.end();
+    }
+
+    //Use this method to trigger the MFA message to use
+    //Pass the auth object containing the user and pass
+    _https_auth_cred (auth, callback) {
+        console.log('_https_auth_cred');
+        if (auth === null || auth === undefined) {
+            return callback(new Error('invalid_credentials'));
+        }
+        let postdata = this._https_auth_postdata_auth(auth);
+
+        var timeout = setTimeout(() => {
+            request.abort();
+        }, refreshTimeout);
+
+        const url = parse('https://oauth.ring.com/oauth/token');
+        url.method = 'POST';
+        url.headers = {
+            'hardware_id': this._uniqueid,
+            'content-type': 'application/json',
+            '2fa-support': 'true',
+            'content-length': postdata.length
+        };
+
+        let request = https.request(url, (response) => {
+            let data = '';
+
+            response.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            response.on('end', () => {
+                let error = null;
+                let result = {};
+
+                if (response.statusCode >= 400) {
+                    if(response.statusCode==412)
+                    {
+                        this._authenticated = false;
+                        console.log('_https_auth_cred : require mfa code : ', response.statusCode);
+                    } else {
+                        this._authenticated = false;
+                        console.log('_https_auth_cred : authentication error : ', response.statusCode);
+                        error = new Error('invalid_authentication ' + response.statusCode + ' ' + data);
+                    }
+                } else {
+                    try {
+                        result = JSON.parse(data);
+                    } catch (e) {
+                        error = e;
+                    }
+                }
+
+                clearTimeout(timeout);
+                callback(error, result);
+            });
+
+            response.on('error', (error) => {
+                clearTimeout(timeout);
+                callback(error);
+            });
+        });
+
+        request.on('error', (error) => {
+            clearTimeout(timeout);
+            callback(error);
+        });
+
+        request.write(postdata);
+
+        request.end();
+
+    }
+
+    //Use this methode to pass the MFA code along with the request
+    _https_auth_code (auth, code, callback) {
+        console.log('_https_auth_code');
+
+        //let auth = Homey.ManagerSettings.get('ringCredentials');
+
+        if (auth === null || auth === undefined) {
+            return callback(new Error('invalid_credentials'));
+        }
+
+        let postdata = this._https_auth_postdata_auth(auth);
+
+        var timeout = setTimeout(() => {
+            request.abort();
+        }, refreshTimeout);
+
+        const url = parse('https://oauth.ring.com/oauth/token');
+        url.method = 'POST';
+        url.headers = {
+            'hardware_id': this._uniqueid,
+            'content-type': 'application/json',
+            '2fa-support': 'true',
+            '2fa-code': code || '',
+            'content-length': postdata.length
+        };
+
+        let request = https.request(url, (response) => {
+            let data = '';
+
+            response.on('data', (chunk) => {
+                data += chunk;
+            });
+
+            response.on('end', () => {
+                let error = null;
+                let result = {};
+
+                if (response.statusCode >= 400) {
+                    this._authenticated = false;
+                    console.log('_https_auth_code : invalid_authentication : ', response.statusCode);
                     error = new Error('invalid_authentication ' + response.statusCode + ' ' + data);
                 } else {
                     try {
                         result = JSON.parse(data);
+                        console.log('_https_auth_code: retrieved the refresh and access token')
+                        Homey.ManagerSettings.set('ringRefreshToken', result.refresh_token);
+                        //console.log('_https_auth_code: refresh token ['+result.refresh_token+']')
+                        this._bearer = result.access_token;
+                        Homey.ManagerSettings.set('ringBearer', result.access_token);
+                        //console.log('_https_auth_code: bearer token ['+result.access_token+']')
+                        this._authenticated = true;
                     } catch (e) {
                         error = e;
                     }
@@ -214,11 +376,6 @@ class Api extends Homey.SimpleClass {
             postdata = [];
 
         if (method === 'POST') {
-            let auth = Homey.ManagerSettings.get('ringCredentials');
-
-            if (auth === null || auth === undefined) {
-                return callback(new Error('invalid_credentials'));
-            }
 
             postdata['device[os]'] = 'ios',
             postdata['device[hardware_id]'] = this._uniqueid;
@@ -226,7 +383,6 @@ class Api extends Homey.SimpleClass {
 
             postdata = JSON.stringify(postdata);
 
-            //headers['Authorization'] = 'Basic ' + new Buffer(auth.user + ':' + auth.pass).toString('base64');
             headers['hardware_id'] = this._uniqueid;
             headers['authorization'] = 'Bearer ' + this._bearer;
             headers['Content-Type'] = 'application/x-www-form-urlencoded';
@@ -313,23 +469,7 @@ class Api extends Homey.SimpleClass {
     _onSetSettings (name) {
         console.log('_onSetSettings', name);
 
-        if (name === 'ringCredentials') {
-            let auth = Homey.ManagerSettings.get(name);
-
-            if (auth == null) {
-                this._authenticated = false;
-                return;
-            }
-
-            this._authenticate((error, result) => {
-                if (error) {
-                    Homey.ManagerApi.realtime('com.ring.status', { state: error });
-                    return console.log(error);
-                }
-
-                Homey.ManagerApi.realtime('com.ring.status', { state: 'authenticated'});
-            });
-        } else if (name === 'ringAccesstoken') {
+        if (name === 'ringAccesstoken') {
             let token = Homey.ManagerSettings.get(name);
 
             if (token == null) {
@@ -358,10 +498,11 @@ class Api extends Homey.SimpleClass {
         }
     }
 
+    //This method requires that the refresh token is already present
     _authenticate (callback) {
         console.log('_authenticate');
 
-        this._https_auth((error, result) => {
+        this._https_auth_mfa_refresh((error, result) => {
             if (error) {
                 this._authenticated = false;
                 return callback(error);
@@ -443,7 +584,7 @@ class Api extends Homey.SimpleClass {
         for (let i = 0; i < retries; i++) {
             this._https('POST', '/snapshots/timestamps', postdata, false, (error, result) => {
                 if (error) {
-                    this._https_auth((error, result) => {
+                    this._https_auth_mfa_refresh((error, result) => {
                         if (error) {
                             this._authenticated = false;
                         } else {
@@ -466,7 +607,7 @@ class Api extends Homey.SimpleClass {
         /* new_image indicates a fresh image, but we always return a image anyway */
         this._https('GET', '/snapshots/image/' + device_data.id, null, true, (error, result) => {
             if (error) {
-                this._https_auth((error, result) => {
+                this._https_auth_mfa_refresh((error, result) => {
                     if (error) {
                         this._authenticated = false;
                         return callback(error, result);

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -35,7 +35,7 @@ class Api extends Homey.SimpleClass {
 
         setInterval(this._refreshDevice.bind(this), refreshDeviceInterval);
         setInterval(this._refreshDevices.bind(this), refreshDevicesInterval);
-        //setInterval(this._verifyAuthentication.bind(this), verifyAuthenticationInterval);
+        setInterval(this._verifyAuthentication.bind(this), verifyAuthenticationInterval);
     }
 
     init () {

--- a/lib/Driver.js
+++ b/lib/Driver.js
@@ -7,6 +7,44 @@ class Driver extends Homey.Driver {
     onPair (socket) {
         this.log('onPair');
 
+        socket.on('showView', (viewId,callback)=>{
+            callback();
+            if(viewId=='start')
+            {
+                console.log('start view loading, check validation');
+                if(Homey.app._api._authenticated)
+                {
+                    console.log('API is already authenticated, skip authentication');
+                    socket.showView('list_devices');
+                } else {
+                    console.log('API is not yet authenticated, perform authentication');
+                }
+            }
+        });
+
+        //Trigger the MFa code message to the user and tell the interface to allow code entry
+        socket.on('triggerMFA', (auth, callback) => {
+            Homey.app._api._https_auth_cred(auth, (error, result) => {
+                if (error) {
+                    return callback(error,null);
+                } else {
+                    console.log('login successfull, now request mfa code');
+                    return callback(null,result);
+                }
+            });
+        });
+
+        //Trigger the MFa code message to the user and tell the interface to allow code entry
+        socket.on('validateMFA', (auth,  callback) => {
+            Homey.app._api._https_auth_code(auth, auth.token, (error, result) => {
+                if (error) {
+                    return callback(error,null);
+                } else {
+                    return callback(null,result);
+                }
+            });
+        });
+
         socket.on('list_devices', (data, callback) => {
             if (this._onPairListDevices) {
                 this._onPairListDevices(data, callback);
@@ -15,13 +53,6 @@ class Driver extends Homey.Driver {
             }
         });
 
-        socket.on('authenticate', (data, callback) => {
-            if (Homey.ManagerSettings.get('ringAccesstoken')) return callback(null, true);
-
-            console.log('invalid_token');
-
-            return callback(new Error('invalid_token'));
-        });
     }
 
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,11 +8,13 @@
         "intro": "Before Homey can add Ring products we need authentication.",
         "auth": {
             "header": "Ring Authentication Credentials",
-            "warning": "Two-Factor Authentication is not supported, you must disable this on your Ring account!",
+            "warning": "Two-Factor Authentication is required, you must enable this on your Ring account!",
             "user": "Email",
             "pass": "Password",
             "authenticate": "Authenticate",
-            "revoke": "Revoke Authentication"
+            "revoke": "Revoke Authentication",
+            "token": "Enter MFA code you received",
+            "validatecode": "Authorize"
         }
     }
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -8,11 +8,13 @@
         "intro": "Voordat Homey Ring producten kan toevoegen moet er autorisatie gegeven worden.",
         "auth": {
             "header": "Ring Autorisatie Gegevens",
-            "warning": "Two-Factor Authenticatie is niet ondersteund, dit moet uitgeschakeld zijn op je Ring account!",
+            "warning": "Two-Factor Authenticatie is vereist, dit moet ingeschakeld zijn op je Ring account!",
             "user": "Email",
             "pass": "Wachtwoord",
             "authenticate": "Autoriseer",
-            "revoke": "Verwijder autorisatie"
+            "revoke": "Verwijder autorisatie",
+            "token": "Enter MFA code welke je ontvangen hebt",
+            "validatecode": "Authoriseren"
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/settings/index.html
+++ b/settings/index.html
@@ -11,58 +11,31 @@
 
     <fieldset>
         <legend data-i18n="settings.auth.header"></legend>
+        
+        <p id="error" style='color: red;'></p>
 
-        <div id="settings-auth">
-            <p id="error" style='color: red;'></p>
-
-            <div class="field row">
-                <label class="form-label" for="settings-auth-user" data-i18n="settings.auth.user"></label>
-                <input class="form-input" id="settings-auth-user" data-i18n-placeholder="" type="text" value=""/>
-            </div>
-
-            <div class="field row">
-                <label class="form-label" for="settings-auth-pass" data-i18n="settings.auth.pass"></label>
-                <input class="form-input" id="settings-auth-pass" data-i18n-placeholder="" type="password" value=""/>
-            </div>
-
-            <button id="settings-auth-authenticate" data-i18n="settings.auth.authenticate"></button>
-        </div>
-
-        <div id="settings-auth-revoke">
-            <button id="settings-auth-revoke" data-i18n="settings.auth.revoke"></button>
-        </div>
+        <button id="settings-auth-revoke" data-i18n="settings.auth.revoke"></button>
     </fieldset>
 
     <script type="text/javascript">
         function onHomeyReady(Homey) {
             Homey.ready();
 
+
             Homey.on('com.ring.status', function (data) {
                 if (data.state !== 'authenticated') {
-                    showAuth();
-                    document.getElementById('error').innerHTML = 'Error: ' + data.state.message;
+                    hideRevoke();
                 } else {
                     document.getElementById('error').innerHTML = '';
-                    showRevoke();
                 }
             });
+
 
             Homey.get('ringAccesstoken', function (err, data) {
-                if (data) {
-                    showRevoke();
+                Homey.alert(JSON.stringify(data));
+                if (!data) {
+                    hideRevoke();
                 }
-
-                Homey.get('ringCredentials', function (err, data) {
-                    if (err || data == undefined) {
-                        console.log(err);
-                    } else {
-                        document.getElementById('settings-auth-user').value = data.user;
-                    }
-                });
-            });
-
-            document.getElementById('settings-auth-authenticate').addEventListener('click', function(elem) {
-                onAuth(Homey);
             });
 
             document.getElementById('settings-auth-revoke').addEventListener('click', function(elem) {
@@ -70,38 +43,19 @@
             });
         }
 
-        showAuth();
-
-        function onAuth(Homey) {
-            var auth = {};
-
-            auth.user = document.getElementById('settings-auth-user').value;
-            auth.pass = document.getElementById('settings-auth-pass').value;
-
-            Homey.set('ringCredentials', auth);
+        function hideRevoke()
+        {
+            document.getElementById('error').innerHTML = 'Error: You need to authenticate this app from the add device wizard';
+            document.getElementById('settings-auth-revoke').style.display = 'none';
         }
 
         function onRevokeAuth(Homey) {
-            Homey.set('ringCredentials', null);
             Homey.set('ringAccesstoken', null);
-            showAuth();
+            Homey.set('ringBearer', null);
+            Homey.set('ringRefreshToken', null);
+            hideRevoke();
         }
 
-        function showAuth() {
-            var revoke = document.getElementById('settings-auth-revoke');
-            revoke.style.display = 'none';
-
-            var auth = document.getElementById('settings-auth');
-            auth.style.display = 'block';
-        }
-
-        function showRevoke() {
-            var auth = document.getElementById('settings-auth');
-            auth.style.display = 'none';
-
-            var revoke = document.getElementById('settings-auth-revoke');
-            revoke.style.display = 'block';
-        }
     </script>
     </body>
 </html>

--- a/settings/index.html
+++ b/settings/index.html
@@ -32,7 +32,6 @@
 
 
             Homey.get('ringAccesstoken', function (err, data) {
-                Homey.alert(JSON.stringify(data));
                 if (!data) {
                     hideRevoke();
                 }


### PR DESCRIPTION
This is a version that supports the MFA requirement.
I added the authorization to the new device wizard. First the user enters their credentials and when they receive their MFA code they can enter it in the now visible box. Then pressing authorize this MFA code is posted to get the refresh token and bearer token.
The refresh token is then stored and a refresh pattern has been added to use that token to get new bearer tokens. So no more user credentials are being stored and the app should remain authorized for a long period (not very well tested at this moment).