### PR TITLE
Stickup cam enable/disable motion detection

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,6 +21,10 @@
             {
                 "name": "Kaoh",
                 "email": "kaoh@kaoh.nl"
+            },
+            {
+                "name": "tokreutz",
+                "email": "tor.kreutzer@gmail.com"
             }
         ]
     },

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -377,7 +377,7 @@ class Api extends Homey.SimpleClass {
         if (postdata == null)
             postdata = [];
 
-        if (method === 'POST') {
+        if (method === 'POST' || method === 'PATCH') {
 
             postdata['device[os]'] = 'ios',
             postdata['device[hardware_id]'] = this._uniqueid;
@@ -412,7 +412,7 @@ class Api extends Homey.SimpleClass {
         let request = https.request({
             host: 'api.ring.com',
             port: 443,
-            path: '/clients_api' + path + '?auth_token=' + this._token + '&api_version=' + this._apiversion ,
+            path: path + '?auth_token=' + this._token + '&api_version=' + this._apiversion ,
             method: method,
             headers: headers,
             agent: false
@@ -463,7 +463,7 @@ class Api extends Homey.SimpleClass {
             callback(error);
         });
 
-        if (method === 'POST') {
+        if (method === 'POST' || method === 'PATCH') {
             request.write(postdata);
         }
 
@@ -540,7 +540,7 @@ class Api extends Homey.SimpleClass {
     _refreshDevice () {
         console.log('_refreshDevice');
 
-        this._https('GET', '/dings/active', null, false, (error, result) => {
+        this._https('GET', '/clients_api/dings/active', null, false, (error, result) => {
             if (error) {
                 return this.error(error);
             }
@@ -562,7 +562,7 @@ class Api extends Homey.SimpleClass {
     }
 
     getDevices (callback) {
-        this._https('GET', '/ring_devices', null, false, (error, result) => {
+        this._https('GET', '/clients_api/ring_devices', null, false, (error, result) => {
             callback(error, result);
         });
     }
@@ -570,35 +570,35 @@ class Api extends Homey.SimpleClass {
     ringChime (device_data, callback) {
         console.log('ringChime', device_data);
 
-        this._https('POST', '/chimes/' + device_data.id + '/play_sound', null, true, (error, result) => {
+        this._https('POST', '/clients_api/chimes/' + device_data.id + '/play_sound', null, true, (error, result) => {
             callback(error, result);
         });
     }
 
     lightOn (device_data, callback) {
         console.log('lightOn', device_data);
-        this._https('PUT', '/doorbots/' + device_data.id + '/floodlight_light_on', null, true, (error, result) => {
+        this._https('PUT', '/clients_api/doorbots/' + device_data.id + '/floodlight_light_on', null, true, (error, result) => {
             callback(error, result);
         });
     }
 
     lightOff (device_data, callback) {
         console.log('lightOff', device_data);
-        this._https('PUT', '/doorbots/' + device_data.id + '/floodlight_light_off', null, true, (error, result) => {
+        this._https('PUT', '/clients_api/doorbots/' + device_data.id + '/floodlight_light_off', null, true, (error, result) => {
             callback(error, result);
         });
     }
 
     sirenOn (device_data, callback) {
         console.log('sirenOn', device_data);
-        this._https('PUT', '/doorbots/' + device_data.id + '/siren_on', null, true, (error, result) => {
+        this._https('PUT', '/clients_api/doorbots/' + device_data.id + '/siren_on', null, true, (error, result) => {
             callback(error, result);
         });
     }
 
     sirenOff (device_data, callback) {
         console.log('sirenOff', device_data);
-        this._https('PUT', '/doorbots/' + device_data.id + '/siren_off', null, true, (error, result) => {
+        this._https('PUT', '/clients_api/doorbots/' + device_data.id + '/siren_off', null, true, (error, result) => {
             callback(error, result);
         });
     }
@@ -614,7 +614,7 @@ class Api extends Homey.SimpleClass {
         postdata['doorbot_ids'] = [device_data.id];
 
         for (let i = 0; i < retries; i++) {
-            this._https('POST', '/snapshots/timestamps', postdata, false, (error, result) => {
+            this._https('POST', '/clients_api/snapshots/timestamps', postdata, false, (error, result) => {
                 if (error) {
                     this._https_auth_mfa_refresh((error, result) => {
                         if (error) {
@@ -637,7 +637,7 @@ class Api extends Homey.SimpleClass {
         }
 
         /* new_image indicates a fresh image, but we always return a image anyway */
-        this._https('GET', '/snapshots/image/' + device_data.id, null, true, (error, result) => {
+        this._https('GET', '/clients_api/snapshots/image/' + device_data.id, null, true, (error, result) => {
             if (error) {
                 console.log(JSON.stringify(error));
                 this._https_auth_mfa_refresh((error, result) => {
@@ -647,7 +647,7 @@ class Api extends Homey.SimpleClass {
                     } else {
                         Homey.ManagerSettings.set('ringBearer', result.access_token);
                         this._bearer = result.access_token;
-                        this._https('GET', '/snapshots/image/' + device_data.id, null, true, (error, result) => {
+                        this._https('GET', '/clients_api/snapshots/image/' + device_data.id, null, true, (error, result) => {
                             return callback(error, result);
                         });
                     }
@@ -661,19 +661,29 @@ class Api extends Homey.SimpleClass {
     enableMotion (device_data, callback) {
         console.log('enableMotion', device_data);
 
-        this._https('POST', '/doorbots/' + device_data.id + '/motions_subscribe', null, true, (error, result) => {
+        let postdata = getMotionSettings(true);
+
+        this._https('PATCH', '/devices/v1/devices/' + device_data.id + '/settings', postdata, false, (error, result) => {
             callback(error, result);
         });
     }
 
     disableMotion (device_data, callback) {
         console.log('disableMotion', device_data);
+    
+        let postdata = getMotionSettings(false);
 
-        this._https('POST', '/doorbots/' + device_data.id + '/motions_unsubscribe', null, true, (error, result) => {
+        this._https('PATCH', '/devices/v1/devices/' + device_data.id + '/settings', postdata, false, (error, result) => {
             callback(error, result);
         });
     }
 
+    getMotionSettings (enabled) {
+        let settings = {};
+        let motionSettings = {};
+        motionSettings['motion_detection_enabled'] = enabled;
+        settings['motion_settings'] = motionSettings;
+    }
 }
 
 module.exports = Api;

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -661,9 +661,12 @@ class Api extends Homey.SimpleClass {
     enableMotion (device_data, callback) {
         console.log('enableMotion', device_data);
 
-        let postdata = getMotionSettings(true);
+        let postdata = this.getMotionSettings(true);
 
         this._https('PATCH', '/devices/v1/devices/' + device_data.id + '/settings', postdata, false, (error, result) => {
+            if (error){
+                console.log(error);
+            }
             callback(error, result);
         });
     }
@@ -671,7 +674,7 @@ class Api extends Homey.SimpleClass {
     disableMotion (device_data, callback) {
         console.log('disableMotion', device_data);
     
-        let postdata = getMotionSettings(false);
+        let postdata = this.getMotionSettings(false);
 
         this._https('PATCH', '/devices/v1/devices/' + device_data.id + '/settings', postdata, false, (error, result) => {
             callback(error, result);
@@ -683,6 +686,8 @@ class Api extends Homey.SimpleClass {
         let motionSettings = {};
         motionSettings['motion_detection_enabled'] = enabled;
         settings['motion_settings'] = motionSettings;
+
+        return settings;
     }
 }
 

--- a/lib/Api.js
+++ b/lib/Api.js
@@ -682,12 +682,11 @@ class Api extends Homey.SimpleClass {
     }
 
     getMotionSettings (enabled) {
-        let settings = {};
-        let motionSettings = {};
-        motionSettings['motion_detection_enabled'] = enabled;
-        settings['motion_settings'] = motionSettings;
-
-        return settings;
+        return {
+            motion_settings: {
+                motion_detection_enabled: enabled
+            }
+        };
     }
 }
 


### PR DESCRIPTION
Was able to reverse engineer the Ring APIs and found the proper Ring endpoint for enabling/disabling motion detection for the stickup cams.

I have validated this with my own Homey and stickup cam, and seems to work as expected.

Should resolve #43 