### PR TITLE
fix: unhandled rejection

### DIFF
--- a/lib/Api.js
+++ b/lib/Api.js
@@ -769,7 +769,7 @@ class Api extends Homey.SimpleClass {
                     this.emit('refresh_locationMode', location);
                 });
             });
-        });
+        }).catch(err => this.error('Failed to refresh location modes', err));
 
     }
     


### PR DESCRIPTION
```
Unhandled Rejection at: Promise {
  <rejected> Error: not_authenticated
      at Api._https (/lib/Api.js:415:33)
      at Api._getLocations (/lib/Api.js:779:14)
      at /lib/Api.js:741:16
      at new Promise (<anonymous>)
      at Api.userLocations (/lib/Api.js:740:16)
      at Api._refreshLocationModes (/lib/Api.js:761:14)
      at listOnTimeout (node:internal/timers:559:17)
      at processTimers (node:internal/timers:502:7)
} reason: Error: not_authenticated
    at Api._https (/lib/Api.js:415:33)
    at Api._getLocations (/lib/Api.js:779:14)
    at /lib/Api.js:741:16
    at new Promise (<anonymous>)
    at Api.userLocations (/lib/Api.js:740:16)
    at Api._refreshLocationModes (/lib/Api.js:761:14)
    at listOnTimeout (node:internal/timers:559:17)
    at processTimers (node:internal/timers:502:7)
```